### PR TITLE
bugfix: split night ti_cai called on ti_ahi

### DIFF
--- a/forms/PSG/SplitNight.html
+++ b/forms/PSG/SplitNight.html
@@ -78,7 +78,7 @@
       "ti_supine_duration": clip_minutes(ti_supine_duration.value), // supine duration (minutes)
       "ti_supine": clip_percent(ti_supine.value), // supine (% TST)
       "ti_ahi": clip_index(ti_ahi.value), // apnea + hypopnea index (events/hour)
-      "ti_cai": clip_index(ti_ahi.value), // central apnea index (events/hour)
+      "ti_cai": clip_index(ti_cai.value), // central apnea index (events/hour)
     };
   }
 


### PR DESCRIPTION
split night titration central apnea index called on wrong element (titration ahi)